### PR TITLE
updated instructions to clarify path to artifacts in 2 places

### DIFF
--- a/CICDINSTRUCTIONS.md
+++ b/CICDINSTRUCTIONS.md
@@ -68,10 +68,11 @@ The instructions use client credential flow to get a token. The token is then us
 1. Enter following values 
     1. Task Version: 1.*
     1. Type : File Path
-    1. Script Path: '$(System.DefaultWorkingDirectory)/<yourartifactname>/Scripts/DeployToB2C.ps1'
+    1. Script Path: '$(System.DefaultWorkingDirectory)/-yourartifactalias-/Scripts/DeployToB2C.ps1'
         - this is the path to the script file you had added earlier. 
-    1. Arguments: -ClientID $(clientId) -ClientSecret $(clientSecret) -TenantId $(tenantId) -PolicyId B2C_1A_TrustFrameworkBase -PathToFile $(System.DefaultWorkingDirectory)/<yourartifactname>/B2CAssets/TrustFrameworkBase.xml
-        - Choose policy names and file path accordingly. 
+    1. Arguments: -ClientID $(clientId) -ClientSecret $(clientSecret) -TenantId $(tenantId) -PolicyId B2C_1A_TrustFrameworkBase -PathToFile $(System.DefaultWorkingDirectory)/-yourartifactalias-/B2CAssets/TrustFrameworkBase.xml
+        - Choose policy names and file path accordingly.
+        - Your artifact alias can be found at the bottom of your Artifacts settings as "Source alias" looks like this: _NameOfMyProject
 1. Save the pipeline. 
 1. Create release and run the pipeline. You can check results if the deployment was successful. 
 1. This sample uploads only one policy. Feel free to modify the PowerShell script to upload more policies. Or you can add the same task with different parameters multiple times.


### PR DESCRIPTION
Note that previously the path was shown as :
 1. Script Path: '$(System.DefaultWorkingDirectory)/<yourartifactalias>/Scripts/DeployToB2C.ps1'

The symbols <> make it into a comment and it does not show in the HTMLS

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->